### PR TITLE
Fix guesser addon and some improvements

### DIFF
--- a/Modules/GuessManager.cs
+++ b/Modules/GuessManager.cs
@@ -115,7 +115,7 @@ public static class GuessManager
             }
         }
         if (!pc.Is(CustomRoles.EvilGuesser))
-        { 
+        {
             if (pc.GetCustomRole().IsImpostor() && !Options.ImpostorsCanGuess.GetBool() && !pc.Is(CustomRoles.Guesser) && !pc.Is(CustomRoles.Councillor))
             {
                 if (!isUI) Utils.SendMessage(GetString("GuessNotAllowed"), pc.PlayerId);
@@ -132,7 +132,7 @@ public static class GuessManager
                 else pc.ShowPopUp(GetString("GuessNotAllowed"));
                 return true;
             }
-        } 
+        }
 
         if (pc.GetCustomRole().IsNK() && !Options.NeutralKillersCanGuess.GetBool() && !pc.Is(CustomRoles.Guesser))
         {
@@ -323,7 +323,7 @@ public static class GuessManager
                     if (!isUI) Utils.SendMessage(GetString("GuessMasochist"), pc.PlayerId);
                     else pc.ShowPopUp(GetString("GuessMasochist"));
                     Main.MasochistKillMax[target.PlayerId]++;
-                    
+
                     if (Main.MasochistKillMax[target.PlayerId] >= Options.MasochistKillMax.GetInt())
                     {
                         CustomWinnerHolder.ResetAndSetWinner(CustomWinner.Masochist);
@@ -337,17 +337,17 @@ public static class GuessManager
                     else pc.ShowPopUp(GetString("SelfGuessMasochist"));
                     guesserSuicide = true;
                 }
-                
+
                 if (role == CustomRoles.GM || target.Is(CustomRoles.GM))
                 {
                     Utils.SendMessage(GetString("GuessGM"), pc.PlayerId);
                     return true;
                 }
-             /*   if (role == CustomRoles.Marshall || target.Is(CustomRoles.Marshall))
-                {
-                    Utils.SendMessage(GetString("GuessMarshall"), pc.PlayerId);
-                    return true;
-                } */
+                /*   if (role == CustomRoles.Marshall || target.Is(CustomRoles.Marshall))
+                   {
+                       Utils.SendMessage(GetString("GuessMarshall"), pc.PlayerId);
+                       return true;
+                   } */
                 if (target.Is(CustomRoles.Snitch) && target.GetPlayerTaskState().IsTaskFinished)
                 {
                     if (!isUI) Utils.SendMessage(GetString("EGGuessSnitchTaskDone"), pc.PlayerId);
@@ -506,20 +506,20 @@ public static class GuessManager
                     }
                 }
 
-         /*       if ((pc.Is(CustomRoleTypes.Impostor) && target.Is(CustomRoleTypes.Impostor) && !Options.ImpCanGuessImp.GetBool()) && Options.GuesserMode.GetBool())
-                {
-                    if (!isUI) Utils.SendMessage(GetString("GuessImpRole"), pc.PlayerId);
-                    else pc.ShowPopUp(GetString("GuessImpRole"));
-                    return true;
+                /*       if ((pc.Is(CustomRoleTypes.Impostor) && target.Is(CustomRoleTypes.Impostor) && !Options.ImpCanGuessImp.GetBool()) && Options.GuesserMode.GetBool())
+                       {
+                           if (!isUI) Utils.SendMessage(GetString("GuessImpRole"), pc.PlayerId);
+                           else pc.ShowPopUp(GetString("GuessImpRole"));
+                           return true;
 
-                }
-                if ((role == CustomRoles.Phantom && pc.Is(CustomRoleTypes.Crewmate) && target.Is(CustomRoleTypes.Crewmate) && !Options.CrewCanGuessCrew.GetBool()) && Options.GuesserMode.GetBool())
-                {
-                    if (!isUI) Utils.SendMessage(GetString("GuessCrewRole"), pc.PlayerId);
-                    else pc.ShowPopUp(GetString("GuessCrewRole"));
-                    return true;
+                       }
+                       if ((role == CustomRoles.Phantom && pc.Is(CustomRoleTypes.Crewmate) && target.Is(CustomRoleTypes.Crewmate) && !Options.CrewCanGuessCrew.GetBool()) && Options.GuesserMode.GetBool())
+                       {
+                           if (!isUI) Utils.SendMessage(GetString("GuessCrewRole"), pc.PlayerId);
+                           else pc.ShowPopUp(GetString("GuessCrewRole"));
+                           return true;
 
-                } */
+                       } */
                 if (target.Is(CustomRoles.Merchant) && Merchant.IsBribedKiller(pc, target))
                 {
                     if (!isUI) Utils.SendMessage(GetString("BribedByMerchant2"), pc.PlayerId);
@@ -549,7 +549,7 @@ public static class GuessManager
                         guesserSuicide = true;
                     }
                 }
-                else if (pc.Is(CustomRoles.NiceGuesser) && target.Is(CustomRoleTypes.Crewmate) && !Options.GGCanGuessCrew.GetBool() && !pc.Is(CustomRoles.Madmate)) 
+                else if (pc.Is(CustomRoles.NiceGuesser) && target.Is(CustomRoleTypes.Crewmate) && !Options.GGCanGuessCrew.GetBool() && !pc.Is(CustomRoles.Madmate))
                 {
                     if (pc.Is(CustomRoles.DoubleShot) && !DoubleShot.IsActive.Contains(pc.PlayerId))
                     {
@@ -570,7 +570,7 @@ public static class GuessManager
                         Logger.Msg($"{guesserSuicide}", "guesserSuicide1");
                     }
                 }
-                else if (pc.Is(CustomRoles.EvilGuesser) && target.Is(CustomRoleTypes.Impostor) && !Options.EGCanGuessImp.GetBool()) 
+                else if (pc.Is(CustomRoles.EvilGuesser) && target.Is(CustomRoleTypes.Impostor) && !Options.EGCanGuessImp.GetBool())
                 {
                     if (pc.Is(CustomRoles.DoubleShot) && !DoubleShot.IsActive.Contains(pc.PlayerId))
                     {
@@ -593,7 +593,7 @@ public static class GuessManager
                 }
                 //  else if (pc.Is(CustomRoles.Guesser)/* && role.IsImpostor() && !Options.GCanGuessImp.GetBool()*/) guesserSuicide = true;
                 //   else if (pc.Is(CustomRoles.Guesser)/* && role.IsCrewmate() && !pc.Is(CustomRoles.Madmate) && !Options.GCanGuessCrew.GetBool() */) guesserSuicide = true;
-                else if (!target.Is(role)) 
+                else if (!target.Is(role))
                 {
                     if (pc.Is(CustomRoles.DoubleShot) && !DoubleShot.IsActive.Contains(pc.PlayerId))
                     {
@@ -687,42 +687,42 @@ public static class GuessManager
 
                 if (!GameStates.IsProceeding)
                 {
-                _ = new LateTask(() =>
-                {
-                    Main.PlayerStates[dp.PlayerId].deathReason = PlayerState.DeathReason.Gambled;
-                    dp.SetRealKiller(pc);
-                    RpcGuesserMurderPlayer(dp);
-
-                    if (dp.Is(CustomRoles.Medic))
-                        Medic.IsDead(dp);
-
-                    if (pc.Is(CustomRoles.Doomsayer) && pc.PlayerId != dp.PlayerId)
+                    _ = new LateTask(() =>
                     {
-                        Doomsayer.GuessingToWin[pc.PlayerId]++;
-                        Doomsayer.SendRPC(pc);
+                        Main.PlayerStates[dp.PlayerId].deathReason = PlayerState.DeathReason.Gambled;
+                        dp.SetRealKiller(pc);
+                        RpcGuesserMurderPlayer(dp);
 
-                        if (!Doomsayer.GuessedRoles.Contains(role))
-                            Doomsayer.GuessedRoles.Add(role);
+                        if (dp.Is(CustomRoles.Medic))
+                            Medic.IsDead(dp);
 
-                        Doomsayer.CheckCountGuess(pc);
-                    }
-
-                    //死者检查
-                    Utils.AfterPlayerDeathTasks(dp, true);
-
-                    Utils.NotifyRoles(isForMeeting: true, NoCache: true);
-
-                    _ = new LateTask(() => { Utils.SendMessage(string.Format(GetString("GuessKill"), Name), 255, Utils.ColorString(Utils.GetRoleColor(CustomRoles.NiceGuesser), GetString("GuessKillTitle"))); }, 0.6f, "Guess Msg");
-
-                    if (pc.Is(CustomRoles.Doomsayer) && pc.PlayerId != dp.PlayerId)
-                    {
-                        _ = new LateTask(() =>
+                        if (pc.Is(CustomRoles.Doomsayer) && pc.PlayerId != dp.PlayerId)
                         {
-                            Utils.SendMessage(string.Format(GetString("DoomsayerGuessCountMsg"), Doomsayer.GuessingToWin[pc.PlayerId]), pc.PlayerId, Utils.ColorString(Utils.GetRoleColor(CustomRoles.Doomsayer), GetString("DoomsayerGuessCountTitle")));
-                        }, 0.7f, "Doomsayer Guess Msg 2");
-                    }
+                            Doomsayer.GuessingToWin[pc.PlayerId]++;
+                            Doomsayer.SendRPC(pc);
 
-                }, 0.2f, "Guesser Kill");
+                            if (!Doomsayer.GuessedRoles.Contains(role))
+                                Doomsayer.GuessedRoles.Add(role);
+
+                            Doomsayer.CheckCountGuess(pc);
+                        }
+
+                        //死者检查
+                        Utils.AfterPlayerDeathTasks(dp, true);
+
+                        Utils.NotifyRoles(isForMeeting: true, NoCache: true);
+
+                        _ = new LateTask(() => { Utils.SendMessage(string.Format(GetString("GuessKill"), Name), 255, Utils.ColorString(Utils.GetRoleColor(CustomRoles.NiceGuesser), GetString("GuessKillTitle"))); }, 0.6f, "Guess Msg");
+
+                        if (pc.Is(CustomRoles.Doomsayer) && pc.PlayerId != dp.PlayerId)
+                        {
+                            _ = new LateTask(() =>
+                            {
+                                Utils.SendMessage(string.Format(GetString("DoomsayerGuessCountMsg"), Doomsayer.GuessingToWin[pc.PlayerId]), pc.PlayerId, Utils.ColorString(Utils.GetRoleColor(CustomRoles.Doomsayer), GetString("DoomsayerGuessCountTitle")));
+                            }, 0.7f, "Doomsayer Guess Msg 2");
+                        }
+
+                    }, 0.2f, "Guesser Kill");
                 }
             }
         }
@@ -1063,7 +1063,7 @@ public static class GuessManager
                     if (!Options.EGCanGuessImp.GetBool() && index == 1) continue;
                     if (!Options.EGCanGuessAdt.GetBool() && index == 3) continue;
                 }
-                if (PlayerControl.LocalPlayer.Is(CustomRoles.Ritualist))
+                else if (PlayerControl.LocalPlayer.Is(CustomRoles.Ritualist))
                 {
                     if (!Options.ConjCanGuessAdt.GetBool() && index == 3) continue;
                 }
@@ -1081,15 +1081,16 @@ public static class GuessManager
                 }
                 else if (PlayerControl.LocalPlayer.Is(CustomRoles.Guesser))
                 {
-                    if (!Options.GCanGuessCrew.GetBool() && PlayerControl.LocalPlayer.Is(CustomRoleTypes.Crewmate) && index == 0) continue;
-                    if (!Options.GCanGuessImp.GetBool() && PlayerControl.LocalPlayer.Is(CustomRoleTypes.Impostor) && index == 1) continue;
+                    Logger.Info("Try creat guesser gui", "Guessergui");
+                    //if (!Options.GCanGuessCrew.GetBool() && index == 0) continue;
+                    //if (!Options.GCanGuessImp.GetBool() && index == 1) continue;
                     if (!Options.GCanGuessAdt.GetBool() && index == 3) continue;
                 }
                 else if (Options.GuesserMode.GetBool())
                 {
-                    if (!Options.CrewCanGuessCrew.GetBool() &&  PlayerControl.LocalPlayer.Is(CustomRoleTypes.Crewmate) && index == 0) continue;
+                    if (!Options.CrewCanGuessCrew.GetBool() && PlayerControl.LocalPlayer.Is(CustomRoleTypes.Crewmate) && index == 0) continue;
                     if (!Options.ImpCanGuessImp.GetBool() && PlayerControl.LocalPlayer.Is(CustomRoleTypes.Impostor) && index == 1) continue;
-                //    if (index == 2) continue;
+                    //    if (index == 2) continue;
                     if (!Options.CanGuessAddons.GetBool() && index == 3) continue;
 
                 }
@@ -1108,7 +1109,7 @@ public static class GuessManager
                     CustomRoleTypes.Crewmate => new Color32(140, 255, 255, byte.MaxValue),
                     CustomRoleTypes.Impostor => new Color32(255, 25, 25, byte.MaxValue),
                     CustomRoleTypes.Neutral => new Color32(127, 140, 141, byte.MaxValue),
-              //      CustomRoleTypes.Coven => new Color32(102, 51, 153, byte.MaxValue),
+                    //      CustomRoleTypes.Coven => new Color32(102, 51, 153, byte.MaxValue),
                     CustomRoleTypes.Addon => new Color32(255, 154, 206, byte.MaxValue),
                     _ => throw new NotImplementedException(),
                 };
@@ -1188,12 +1189,12 @@ public static class GuessManager
             int ind = 0;
             foreach (CustomRoles role in Enum.GetValues(typeof(CustomRoles)))
             {
-                if ( role is CustomRoles.GM 
+                if (role is CustomRoles.GM
                     or CustomRoles.SpeedBooster
-                 //   or CustomRoles.Ritualist
+                    //   or CustomRoles.Ritualist
                     or CustomRoles.Engineer
                     or CustomRoles.Crewmate
-                 //   or CustomRoles.Loyal
+                    //   or CustomRoles.Loyal
                     or CustomRoles.Oblivious
                     or CustomRoles.Baker
                     or CustomRoles.Famine
@@ -1202,14 +1203,14 @@ public static class GuessManager
                     or CustomRoles.Impostor
                     or CustomRoles.Shapeshifter
                     or CustomRoles.Flashman
-                    or CustomRoles.NotAssigned 
-                    or CustomRoles.KB_Normal 
-               //     or CustomRoles.Marshall 
-                    or CustomRoles.Paranoia 
+                    or CustomRoles.NotAssigned
+                    or CustomRoles.KB_Normal
+                    //     or CustomRoles.Marshall 
+                    //or CustomRoles.Paranoia 
                     or CustomRoles.SuperStar
                     or CustomRoles.Konan
                     or CustomRoles.Oblivious
-               //     or CustomRoles.Reflective
+                    //     or CustomRoles.Reflective
                     or CustomRoles.GuardianAngelTOHE
                     ) continue;
 

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -488,8 +488,9 @@ public static class Options
     public static OptionItem ScientistDur;
     public static OptionItem ScientistCD;
 
-    public static OptionItem GCanGuessImp;
-    public static OptionItem GCanGuessCrew;
+    //public static OptionItem GCanGuessImp;
+    //public static OptionItem GCanGuessCrew;
+    //public static OptionItem GCanGuessNeutrals;
     public static OptionItem GCanGuessAdt;
     public static OptionItem GCanGuessTaskDoneSnitch;
     public static OptionItem GTryHideMsg;
@@ -2122,13 +2123,17 @@ public static class Options
             .SetParent(CustomRoleSpawnChances[CustomRoles.Guesser]);
         NeutralCanBeGuesser = BooleanOptionItem.Create(19112, "NeutralCanBeGuesser", true, TabGroup.OtherRoles, false)
             .SetParent(CustomRoleSpawnChances[CustomRoles.Guesser]);
-     //   GCanGuessImp = BooleanOptionItem.Create(19113, "GCanGuessImp", false, TabGroup.OtherRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Guesser]);
-     //   GCanGuessCrew = BooleanOptionItem.Create(19114, "GCanGuessCrew", false, TabGroup.OtherRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Guesser]);
-        GCanGuessAdt = BooleanOptionItem.Create(19115, "GCanGuessAdt", false, TabGroup.OtherRoles, false)
+        //GCanGuessImp = BooleanOptionItem.Create(19113, "GCanGuessImp", true, TabGroup.OtherRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Guesser])
+        //    .SetHidden(true);
+        //GCanGuessCrew = BooleanOptionItem.Create(19114, "GCanGuessCrew", true, TabGroup.OtherRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Guesser])
+        //    .SetHidden(true);
+        //GCanGuessNeutrals = BooleanOptionItem.Create(19115, "GCanGuessNeutrals", true, TabGroup.OtherRoles, false).SetParent(CustomRoleSpawnChances[CustomRoles.Guesser])
+        //    .SetHidden(true);
+        GCanGuessAdt = BooleanOptionItem.Create(19116, "GCanGuessAdt", false, TabGroup.OtherRoles, false)
             .SetParent(CustomRoleSpawnChances[CustomRoles.Guesser]);
-        GCanGuessTaskDoneSnitch = BooleanOptionItem.Create(19116, "GCanGuessTaskDoneSnitch", true, TabGroup.OtherRoles, false)
+        GCanGuessTaskDoneSnitch = BooleanOptionItem.Create(19117, "GCanGuessTaskDoneSnitch", true, TabGroup.OtherRoles, false)
             .SetParent(CustomRoleSpawnChances[CustomRoles.Guesser]);
-        GTryHideMsg = BooleanOptionItem.Create(19117, "GuesserTryHideMsg", true, TabGroup.OtherRoles, false)
+        GTryHideMsg = BooleanOptionItem.Create(19118, "GuesserTryHideMsg", true, TabGroup.OtherRoles, false)
             .SetParent(CustomRoleSpawnChances[CustomRoles.Guesser])
             .SetColor(Color.green);
         SetupAdtRoleOptions(19200, CustomRoles.Fool, canSetNum: true, tab: TabGroup.OtherRoles);

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -2079,14 +2079,37 @@ public static class Utils
                     }
                 }
 
+                if (seer.Is(CustomRoles.EvilGuesser))
+                {
+                    if (seer.IsAlive() && target.IsAlive() && GuesserIsForMeeting)
+                    {
+                        TargetPlayerName = ColorString(GetRoleColor(CustomRoles.EvilGuesser), " " + target.PlayerId.ToString()) + " " + TargetPlayerName;
+                    }
+                }
+
+                if (seer.Is(CustomRoles.NiceGuesser))
+                {
+                    if (seer.IsAlive() && target.IsAlive() && GuesserIsForMeeting)
+                    {
+                        TargetPlayerName = ColorString(GetRoleColor(CustomRoles.NiceGuesser), " " + target.PlayerId.ToString()) + " " + TargetPlayerName;
+                    }
+                }
+
                 if (seer.Is(CustomRoles.Doomsayer))
                 {
                     if (seer.IsAlive() && target.IsAlive() && GuesserIsForMeeting)
                     {
-                        TargetPlayerName = ColorString(GetRoleColor(CustomRoles.Doomsayer), target.PlayerId.ToString()) + " " + TargetPlayerName;
+                        TargetPlayerName = ColorString(GetRoleColor(CustomRoles.Doomsayer), " " + target.PlayerId.ToString()) + " " + TargetPlayerName;
                     }
                 }
 
+                if (seer.Is(CustomRoles.Guesser) && !seer.Is(CustomRoles.Lookout))
+                {
+                    if (seer.IsAlive() && target.IsAlive() && GuesserIsForMeeting)
+                    {
+                        TargetPlayerName = ColorString(GetRoleColor(CustomRoles.Guesser), " " + target.PlayerId.ToString()) + " " + TargetPlayerName;
+                    }
+                }
 
                 if (seer.Is(CustomRoles.Lookout))
                 {

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -586,7 +586,7 @@ internal class ChatCommands
             "網紅" => GetString("CyberStar"),
             "俠客" => GetString("SwordsMan"),
             "正義賭怪" or "正义的赌怪" or "好赌" or "正义赌" => GetString("NiceGuesser"),
-            "邪惡賭怪" or "邪恶的赌怪" or "坏赌" or "恶赌" or "邪恶赌" or "赌怪" => GetString("EvilGuesser"),
+            "邪惡賭怪" or "邪恶的赌怪" or "坏赌" or "恶赌" or "邪恶赌" => GetString("EvilGuesser"),
             "市長" or "逝长" => GetString("Mayor"),
             "被害妄想症" or "被害妄想" or "被迫害妄想症" or "被害" or "妄想" or "妄想症" => GetString("Paranoia"),
             "愚者" or "愚" => GetString("Psychic"),

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -998,7 +998,6 @@ class MeetingHudStartPatch
                     if (!seer.Data.IsDead && !target.Data.IsDead)
                         pva.NameText.text = Utils.ColorString(Utils.GetRoleColor(seer.Is(CustomRoles.NiceGuesser) ? CustomRoles.NiceGuesser : CustomRoles.EvilGuesser), target.PlayerId.ToString()) + " " + pva.NameText.text;
                     break;
-           //     case CustomRoles.Guesser:
                 case CustomRoles.Judge:
                     if (!seer.Data.IsDead && !target.Data.IsDead)
                         pva.NameText.text = Utils.ColorString(Utils.GetRoleColor(CustomRoles.Judge), target.PlayerId.ToString()) + " " + pva.NameText.text;
@@ -1048,24 +1047,23 @@ class MeetingHudStartPatch
                             isLover = true;
                         }
                         break;
-              /*      case CustomRoles.Guesser:
-                        if (!target.Data.IsDead)
-                        {
-                            sb.Append(Utils.ColorString(Utils.GetRoleColor(CustomRoles.Lookout), " " + target.PlayerId.ToString()) + " ");
-                        }
+                    /*      case CustomRoles.Guesser:
+                              if (!target.Data.IsDead)
+                              {
+                                  sb.Append(Utils.ColorString(Utils.GetRoleColor(CustomRoles.Lookout), " " + target.PlayerId.ToString()) + " ");
+                              }
+                              break;
+                     /*     case CustomRoles.Sidekick:
+                          if (seer.Is(CustomRoles.Sidekick) && target.Is(CustomRoles.Sidekick) && Options.SidekickKnowOtherSidekick.GetBool())
+                          {
+                              sb.Append(Utils.ColorString(Utils.GetRoleColor(CustomRoles.Jackal), " ♥")); //変更対象にSnitchマークをつける
+                          sb.Append(Snitch.GetWarningMark(seer, target));
+                          }
+                          break; */
+                    case CustomRoles.Guesser:
+                        if (!seer.Data.IsDead && !target.Data.IsDead)
+                            pva.NameText.text = Utils.ColorString(Utils.GetRoleColor(CustomRoles.Guesser), target.PlayerId.ToString()) + " " + pva.NameText.text;
                         break;
-               /*     case CustomRoles.Sidekick:
-                    if (seer.Is(CustomRoles.Sidekick) && target.Is(CustomRoles.Sidekick) && Options.SidekickKnowOtherSidekick.GetBool())
-                    {
-                        sb.Append(Utils.ColorString(Utils.GetRoleColor(CustomRoles.Jackal), " ♥")); //変更対象にSnitchマークをつける
-                    sb.Append(Snitch.GetWarningMark(seer, target));
-                    }
-                    break; */
-                 //   case CustomRoles.Guesser:
-                //    if (!seer.Data.IsDead && !target.Data.IsDead)
-                 //       pva.NameText.text = Utils.ColorString(Utils.GetRoleColor(seer.GetCustomRole()), target.PlayerId.ToString()) + " " + pva.NameText.text;
-
-                //    break;
                 }
             }
 

--- a/Resources/String.csv
+++ b/Resources/String.csv
@@ -1366,6 +1366,7 @@
 "GuesserTryHideMsg","尝试混淆赌怪指令（试验性）","Try to hide guesser's command","Спрятать команду <color=#eede26>Угадывателя</color>","嘗試隱藏賭怪指令(試驗性)","尝试混淆赌怪指令（试验性）"
 "GCanGuessImp","<color=#ff1919>内鬼</color>可以猜测<color=#ff1919>内鬼</color>身份","<color=#ff1919>Impostor</color> can guess <color=#ff1919>Impostor</color> roles","<color=#ff1919>Предатели</color> могут угадывать роли <color=#ff1919>Предателей</color>ы","",""
 "GCanGuessCrew","<color=#8cffff>成员</color>可以猜测<color=#8cffff>船员</color>身份","<color=#8cffff>Crewmate</color> can guess <color=#8cffff>Crewmate</color> roles","<color=#8cffff>Члены Экипажа</color> могут угадывать роли <color=#8cffff>Членов Экипажа</color>","",""
+"GCanGuessNeutrals","<color=#8cffff>成员</color>可以猜测<color=#8cffff>中立</color>身份","<color=#8cffff>Crewmate</color> can guess <color=#8cffff>Crewmate</color> roles","<color=#8cffff>Члены Экипажа</color> могут угадывать роли <color=#8cffff>Членов Экипажа</color>","",""
 "GCanGuessAdt","可以猜测附加职业","Can guess Add-ons","Может угадывать Атрибуты","",""
 "GCanGuessTaskDoneSnitch","可以猜测完成任务的<color=#b8fb4f>告密者</color>","Can guess <color=#b8fb4f>Snitch</color> with All Tasks Done","Может угадать <color=#b8fb4f>Стукача</color> который выполнил свои задания","可以猜測完成任務的<color=#b8fb4f>告密者</color>","可以猜测完成任务的<color=#b8fb4f>告密者</color>"
 "BountyTargetChangeTime","赏金目标切换时间","Time Until Target Swaps","Время смены цели","賞金目標切換時間","赏金目标切换时间"


### PR DESCRIPTION
1.Fix guesser addon gui not working (someone made the option item unreachable and always false)
2.Fix guesser addon not showing ids in meetings
3.Add eg,gg,guesser ids for in game names (if we add this for doomsayer , we should also do this for other guessers. Also this seems to be always not working)
4.add some translation for guesser addon (Im lazy...so I didnt do all)
5.remove some roles from "hidden list" (if we can guess them using /bt,then hide them in gui?)
for 5 I did not check every role.

I didnt touch the codes left there , and I left options (if u wish to use it)