### PR TITLE
Fix friendcode not exist player become moderator

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -1562,6 +1562,7 @@ public static class Utils
     }
     public static bool IsPlayerModerator(string friendCode)
     {
+        if (friendCode == "") return false;
         var friendCodesFilePath = @"./TOHE-DATA/Moderators.txt";
         var friendCodes = File.ReadAllLines(friendCodesFilePath);
         return friendCodes.Any(code => code.Contains(friendCode));


### PR DESCRIPTION
Apparently it's a dumb bug I forgot to consider...
I do wonder why nobody reported the bug