### PR TITLE
Add "KeyCode.Shift" For Num Options & Aslo "Fix SyncOptions" (No)

### DIFF
--- a/Patches/GameOptionsMenuPatch.cs
+++ b/Patches/GameOptionsMenuPatch.cs
@@ -335,10 +335,9 @@ public class StringOptionIncreasePatch
         var option = OptionItem.AllOptions.FirstOrDefault(opt => opt.OptionBehaviour == __instance);
         if (option == null) return true;
 
-        option.SetValue(option.CurrentValue + 1);
+        option.SetValue(option.CurrentValue + (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift) ? 5 : 1));
         return false;
     }
-    public static void Postfix(StringOption __instance) => OptionShower.GetText();
 }
 
 [HarmonyPatch(typeof(StringOption), nameof(StringOption.Decrease))]
@@ -349,10 +348,9 @@ public class StringOptionDecreasePatch
         var option = OptionItem.AllOptions.FirstOrDefault(opt => opt.OptionBehaviour == __instance);
         if (option == null) return true;
 
-        option.SetValue(option.CurrentValue - 1);
+        option.SetValue(option.CurrentValue - (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift) ? 5 : 1));
         return false;
     }
-    public static void Postfix(StringOption __instance) => OptionShower.GetText();
 }
 
 [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.RpcSyncSettings))]


### PR DESCRIPTION
Added the ability to change the settings number to +5 when the Shift button is pressed instead of 1 by default

Before:
![image](https://github.com/Loonie-Toons/TownOfHost-ReEdited/assets/104814436/0e28e823-5d83-4753-9ba8-77cff37ee9f7)

After:
![image](https://github.com/Loonie-Toons/TownOfHost-ReEdited/assets/104814436/412980f1-ae39-430f-ac8f-ed4cf0630e8c)
