### PR TITLE
Improve certain role conflicts about guesser

### DIFF
--- a/Modules/CustomRolesHelper.cs
+++ b/Modules/CustomRolesHelper.cs
@@ -2,6 +2,7 @@ using AmongUs.GameOptions;
 using System.Linq;
 using TOHE.Roles.Crewmate;
 using TOHE.Roles.Neutral;
+using static UnityEngine.GraphicsBuffer;
 
 namespace TOHE;
 
@@ -949,6 +950,7 @@ internal static class CustomRolesHelper
                 if (pc.Is(CustomRoles.Trapper)
                     || pc.Is(CustomRoles.Unreportable)
                     || pc.Is(CustomRoles.Burst)
+                    || (pc.Is(CustomRoles.Onbound) && Options.BaitNotification.GetBool())
                     || pc.Is(CustomRoles.GuardianAngelTOHE))
                     return false;
                 if ((pc.GetCustomRole().IsCrewmate() && !Options.CrewCanBeBait.GetBool()) || (pc.GetCustomRole().IsNeutral() && !Options.NeutralCanBeBait.GetBool()) || (pc.GetCustomRole().IsImpostor() && !Options.ImpCanBeBait.GetBool()))
@@ -975,16 +977,23 @@ internal static class CustomRolesHelper
                     || pc.Is(CustomRoles.DoubleShot)
                     || pc.Is(CustomRoles.Mafia)
                     || pc.Is(CustomRoles.Councillor)
-                    || pc.Is(CustomRoles.GuardianAngelTOHE)
-                    || pc.Is(CustomRoles.God))
+                    || pc.Is(CustomRoles.GuardianAngelTOHE))
                     return false;
+                if ((pc.Is(CustomRoles.Phantom) && !Options.PhantomCanGuess.GetBool())
+                    || (pc.Is(CustomRoles.Terrorist) && (!Options.TerroristCanGuess.GetBool() || Options.CanTerroristSuicideWin.GetBool()))
+                    || (pc.Is(CustomRoles.Workaholic) && !Options.WorkaholicCanGuess.GetBool())
+                    || (pc.Is(CustomRoles.God) && !Options.GodCanGuess.GetBool()))
+                    return false; //Based on guess manager
                 if ((pc.GetCustomRole().IsCrewmate() && !Options.CrewCanBeGuesser.GetBool()) || (pc.GetCustomRole().IsNeutral() && !Options.NeutralCanBeGuesser.GetBool()) || (pc.GetCustomRole().IsImpostor() && !Options.ImpCanBeGuesser.GetBool()))
                     return false;
                 break;
 
             case CustomRoles.Onbound:
-                if (pc.Is(CustomRoles.SuperStar))
-                    return false;
+                if (pc.Is(CustomRoles.SuperStar)
+                    || (pc.Is(CustomRoles.Doctor) && Options.DoctorVisibleToEveryone.GetBool())
+                    || (pc.Is(CustomRoles.Bait) && Options.BaitNotification.GetBool())
+                    || pc.Is(CustomRoles.Glow) || pc.Is(CustomRoles.LastImpostor) || pc.Is(CustomRoles.Mare))
+                    return false; //Based on guess manager
                 if ((pc.GetCustomRole().IsCrewmate() && !Options.CrewCanBeOnbound.GetBool()) || (pc.GetCustomRole().IsNeutral() && !Options.NeutralCanBeOnbound.GetBool()) || (pc.GetCustomRole().IsImpostor() && !Options.ImpCanBeOnbound.GetBool()))
                     return false;
                 break;
@@ -1256,7 +1265,8 @@ internal static class CustomRolesHelper
                     || pc.Is(CustomRoles.Bomber)
                     || pc.Is(CustomRoles.Nuker)
                     || pc.Is(CustomRoles.BoobyTrap)
-                    || pc.Is(CustomRoles.Capitalism))
+                    || pc.Is(CustomRoles.Capitalism)
+                    || pc.Is(CustomRoles.Onbound))
                     return false;
                 if (!pc.GetCustomRole().IsImpostor())
                     return false;
@@ -1342,6 +1352,7 @@ internal static class CustomRolesHelper
                 break;
 
             case CustomRoles.Glow:
+                if (pc.Is(CustomRoles.Onbound)) return false;
                 if ((pc.GetCustomRole().IsCrewmate() && !Options.CrewCanBeGlow.GetBool()) || (pc.GetCustomRole().IsNeutral() && !Options.NeutralCanBeGlow.GetBool()) || (pc.GetCustomRole().IsImpostor() && !Options.ImpCanBeGlow.GetBool()))
                     return false;
                 break;

--- a/Resources/Data/en.json
+++ b/Resources/Data/en.json
@@ -1228,7 +1228,7 @@
   "PoisonerKillDelay": "Poison Kill Delay",
   "CanVent": "Can Vent",
   "CanKill": "Can Kill",
-  "CanGuess": "Can Guess in Guesser Mode",
+  "CanGuess": "Can Guess in Guesser Mode or as Guesser",
   "BombCooldown": "Bomb Cooldown",
   "SniperCanKill": "<color=#ff1919>Sniper</color> can kill with bullets remaining",
   "CrewmatesCanBeSidekick": "<color=#8cffff>Crewmates</color> can be <color=#00b4eb>Sidekick</color>",

--- a/Resources/Data/zh-CN.json
+++ b/Resources/Data/zh-CN.json
@@ -1228,7 +1228,7 @@
   "PoisonerKillDelay": "毒杀延迟",
   "CanVent": "可以使用通风管道",
   "CanKill": "可以击杀",
-  "CanGuess": "可以在猜测模式下进行猜测",
+  "CanGuess": "可以在猜测模式下或作为赌怪进行猜测",
   "BombCooldown": "炸弹冷却",
   "SniperCanKill": "<color=#ff1919>狙击手</color>可以在还有剩余子弹的情况下杀人",
   "CrewmatesCanBeSidekick": "<color=#8cffff>船员阵营</color>可以成为<color=#00b4eb>跟班</color>",

--- a/Resources/Data/zh-TW.json
+++ b/Resources/Data/zh-TW.json
@@ -1228,7 +1228,7 @@
   "PoisonerKillDelay": "PoisonerKillDelay",
   "CanVent": "可以使用通風管",
   "CanKill": "",
-  "CanGuess": "",
+  "CanGuess": "可以在猜測模式下或作為賭怪進行猜測",
   "BombCooldown": "",
   "SniperCanKill": "",
   "CrewmatesCanBeSidekick": "",


### PR DESCRIPTION
1. Whether Phantom, Terrorist, Workaholic, God can be guesser is now decided by its settings
2. Update string for (1)
3. Obvious roles now won't be onBound (They cant be guessed anyway) //Based on codes in guess manager